### PR TITLE
add jupyterlab functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,41 @@ Weaver URL is https://pavics.ouranos.ca/weaver/
 >>> print(f"Weaver URL is {MarbleClient()['PAVICS'].weaver}")
 Weaver URL is https://pavics.ouranos.ca/weaver/
 ```
+
+## Jupyterlab functionality
+
+When running in a Marble Jupyterlab environment, the client can take advantage of various environment variables and 
+Jupyter's API to provide some additional functionality. 
+
+> [!WARNING]
+> Calling any of the methods described below outside a Marble Jupyterlab environment will raise a 
+> `JupyterEnvironmentError`.
+
+Get the node your notebook/script is currently running on:
+
+```python
+>>> client = MarbleClient()
+>>> client.current_node
+<marble_client.node.MarbleNode at 0x10c129990>
+```
+
+Add Magpie cookies to a `requests.Session` object. This means that any request made with that session variable will
+be made as if you were logged in to the current Marble node. This is the recommended way to access protected resources
+programmatically in your scripts:
+
+```python
+>>> client = MarbleClient()
+>>> session = requests.Session
+>>> client.magpie_session(session)
+>>> session.cookies.get_dict()
+{...} # session cookiejar now includes magpie cookies
+```
+
+You can also use the `magpie_session` method to create a new `requests.Sesssion` object:
+
+```python
+>>> client = MarbleClient()
+>>> session = client.magpie_session()
+>>> session.cookies.get_dict()
+{...} # now includes magpie cookies
+```

--- a/README.md
+++ b/README.md
@@ -120,27 +120,27 @@ Get the node your notebook/script is currently running on:
 
 ```python
 >>> client = MarbleClient()
->>> client.current_node
+>>> client.this_node
 <marble_client.node.MarbleNode at 0x10c129990>
 ```
 
-Add Magpie cookies to a `requests.Session` object. This means that any request made with that session variable will
+Add session cookies to a `requests.Session` object. This means that any request made with that session variable will
 be made as if you were logged in to the current Marble node. This is the recommended way to access protected resources
 programmatically in your scripts:
 
 ```python
 >>> client = MarbleClient()
 >>> session = requests.Session
->>> client.magpie_session(session)
+>>> client.this_session(session)
 >>> session.cookies.get_dict()
-{...} # session cookiejar now includes magpie cookies
+{...} # session cookiejar now includes cookies
 ```
 
-You can also use the `magpie_session` method to create a new `requests.Sesssion` object:
+You can also use the `this_session` method to create a new `requests.Sesssion` object:
 
 ```python
 >>> client = MarbleClient()
->>> session = client.magpie_session()
+>>> session = client.this_session()
 >>> session.cookies.get_dict()
-{...} # now includes magpie cookies
+{...} # now includes session cookies
 ```

--- a/README.md
+++ b/README.md
@@ -144,3 +144,10 @@ You can also use the `this_session` method to create a new `requests.Sesssion` o
 >>> session.cookies.get_dict()
 {...} # now includes session cookies
 ```
+
+You can now make a request to a protected resource on the current node using this session object. You will be able to 
+access the resource if you have permission:
+
+```python
+>>> session.get(f"{client.this_node.url}/some/protected/subpath")
+```

--- a/marble_client/client.py
+++ b/marble_client/client.py
@@ -72,7 +72,7 @@ class MarbleClient:
     @property
     @cache
     @check_jupyterlab
-    def current_node(self) -> MarbleNode:
+    def this_node(self) -> MarbleNode:
         """
         Return the node where this script is currently running.
 
@@ -85,9 +85,9 @@ class MarbleClient:
         raise UnknownNodeError(f"No node found in the registry with the url {host_url}")
 
     @check_jupyterlab
-    def magpie_session(self, session: Optional[requests.Session]) -> requests.Session:
+    def this_session(self, session: Optional[requests.Session]) -> requests.Session:
         """
-        Add the Magpie cookies of the user who is currently logged in to the session object.
+        Add the login session cookies of the user who is currently logged in to the session object.
         If a session object is not passed as an argument to this function, create a new session
         object as well.
 

--- a/marble_client/exceptions.py
+++ b/marble_client/exceptions.py
@@ -8,3 +8,7 @@ class ServiceNotAvailableError(MarbleBaseError):
 
 class UnknownNodeError(MarbleBaseError):
     pass
+
+
+class JupyterEnvironmentError(MarbleBaseError):
+    pass


### PR DESCRIPTION
When running in a Marble Jupyterlab environment, the client can take advantage of various environment variables and 
Jupyter's API to provide some additional functionality. 

This PR adds two new instance methods to the `MarbleClient` object:

- `current_node`: property that returns the node the user is currently logged into
- `magpie_session`: method that add the magpie cookies to a `requests.Session` object

Note that both of these will only work if the script is actually being run in a Marble Jupyterlab environment. Otherwise an error will be raised.


To discuss:

- I'm not sure about the name `magpie_session` since I don't know if we want the user to have to know what Magpie is in order to figure out what the function does. Some other possible function names: `session_login`, `marble_login`, `marble_session`