### PR TITLE
make session arg a kwarg

### DIFF
--- a/marble_client/client.py
+++ b/marble_client/client.py
@@ -85,7 +85,7 @@ class MarbleClient:
         raise UnknownNodeError(f"No node found in the registry with the url {host_url}")
 
     @check_jupyterlab
-    def this_session(self, session: Optional[requests.Session]) -> requests.Session:
+    def this_session(self, session: Optional[requests.Session] = None) -> requests.Session:
         """
         Add the login session cookies of the user who is currently logged in to the session object.
         If a session object is not passed as an argument to this function, create a new session


### PR DESCRIPTION
The documentation states that you should be able to call `MarbleClient.this_session` with no arguments and it will create a new `requests.Session` object to return. 

However, the `session` argument had no default so the argument was required. 

This PR adds a default value of `None` to this argument so that the method can be called with no explicit arguments as intended.